### PR TITLE
Expose s3Upload through module exports

### DIFF
--- a/src/riffraff-artefact.js
+++ b/src/riffraff-artefact.js
@@ -213,7 +213,8 @@ function determineAction() {
 module.exports = {
     determineAction: determineAction,
     settings: SETTINGS,
-    buildManifest: buildManifest
+    buildManifest: buildManifest,
+    s3Upload: s3Upload
 }
 
 if (require.main === module) {


### PR DESCRIPTION
I want to use `s3Upload` without any of the other steps.

@hmgibson23 @piuccio 
