### PR TITLE
Change the order of parameters in tar creation

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -76,7 +76,7 @@ function createTar(sourceDir, targetFolder, targetName) {
         };
 
         const exclude = "--exclude='" + targetName + ".tgz'";
-        const commandString = ["tar czf", targetLocation, sourceDir, exclude].join(" ");
+        const commandString = ["tar czf", targetLocation, exclude, sourceDir].join(" ");
         log("Running: " + commandString);
         exec(commandString, result);
     });


### PR DESCRIPTION
The exclude parameter must be between the target filename and the input, otherwise it's considered as an imput file to the tar archive.
