### PR TITLE
Configure manifest project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Plugin for building deployable RiffRaff artefacts in Node. Supports RiffRaff deployment types:
 
-- `cloud-formation` 
-- `aws-lambda` 
+- `cloud-formation`
+- `aws-lambda`
 - `autoscaling`
 
 ## Getting Started
@@ -14,6 +14,7 @@ To use it, ensure you have a `package.json` located in the root directory of you
 ### Options
 - `isAwsLambda`: `true` or `false` (optional - defaults to `false`)
 - `cloudformation`: `false` or the location of your cloudformation (optional - defaults to `cloudformation.json`)
+- `projectName`: a string with the name you want to appear in RiffRaff dropdown (e.g. `team::project` - defaults to `name` in package.json)
 
 Some example `package.json`:
 
@@ -22,7 +23,7 @@ Some example `package.json`:
 {
   "name": "s3watcher",
   "...": "...",
-  "cloudformation": "my_clouformation.json" 
+  "cloudformation": "my_clouformation.json"
 }
 ```
 
@@ -49,7 +50,7 @@ By default, this plugin will build the tgz file from the default directory (the 
 
 ### Build environment support
 Works on:
-- [Circle CI](https://circleci.com/) 
+- [Circle CI](https://circleci.com/)
 - [Travis](https://travis-ci.org/)
 - [Jenkins](https://jenkins-ci.org/) with the [Git plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-riffraff-artefact",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Deploy RiffRaff Artefacts",
   "main": "dist/riffraff-artefact.js",
   "bin": {

--- a/src/riffraff-artefact.js
+++ b/src/riffraff-artefact.js
@@ -142,7 +142,7 @@ function buildManifest() {
         revision: SETTINGS.vcsRevision,
         startTime: SETTINGS.buildStartTime,
         buildNumber: SETTINGS.buildId,
-        projectName: SETTINGS.packageName
+        projectName: SETTINGS.manifestProjectName || SETTINGS.packageName
     };
 }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -18,11 +18,13 @@ log("Reading configuration from " + ROOT + "/package.json");
 
 const packageJson = require(ROOT + "/package.json");
 const cf = packageJson.cloudformation;
+const projectName = packageJson.projectName;
 
 let SETTINGS = {
     rootDir: ROOT,
     artefactsFilename: "artifacts.zip",
     packageName: packageJson.name,
+    manifestProjectName: projectName || packageJson.name,
     cloudformation: (cf == undefined) ? "cloudformation.json" : cf,
     buildStartTime: getDate(),
     projectBranchName: getBranchName() || "Unknown",


### PR DESCRIPTION
Riffraff distinguishes between project name and manifest project name.
The latter is used in the dropdown.
