### PR TITLE
Expose a method to upload all artefacts in a folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "node-riffraff-artefact",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Deploy RiffRaff Artefacts",
   "main": "dist/riffraff-artefact.js",
   "bin": {
     "riffraff-artefact": "./bin/main"
   },
   "files": [
-      "bin",
-      "dist"
+    "bin",
+    "dist"
   ],
   "scripts": {
     "prepublish": "npm test && npm run build",
@@ -20,9 +20,10 @@
   "author": "Hugo Gibson",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.3.15",
-    "babel-cli": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
+    "aws-sdk": "^2.4.14",
+    "babel-cli": "^6.11.4",
+    "babel-preset-es2015": "^6.13.2",
+    "glob": "^7.0.5",
     "q": "^1.4.1"
   },
   "repository": {
@@ -30,6 +31,6 @@
     "url": "https://github.com/guardian/node-riffraff-artefact.git"
   },
   "devDependencies": {
-    "eslint": "^2.10.2"
+    "eslint": "^3.2.2"
   }
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,6 +1,7 @@
 const exec = require("child_process").exec;
 const fs = require("fs");
 const Q = require("q");
+const glob = require("glob");
 
 const SETTINGS = require("../settings").SETTINGS;
 
@@ -82,11 +83,20 @@ function createTar(sourceDir, targetFolder, targetName) {
     });
 }
 
+function listFiles(sourceDir) {
+    return glob.sync("**/*", {
+        cwd: sourceDir,
+        nosort: true,
+        nodir: true
+    });
+}
+
 
 module.exports = {
     log,
     createDir,
     createZip,
     createTar,
-    copyFile
+    copyFile,
+    listFiles
 };


### PR DESCRIPTION
This doesn't change the default behaviour, but simply exposes a method to upload files without bundling them in a `zip`.

I've got the feeling that the majority of apps using this module don't rely on the default behaviour anyway, that is zipping the entire project.
At least none of my projects use that.

Users will have to replace `riffraff.s3Upload();` with `riffraff.s3FilesUpload();`

fyi @sihil 
