### PR TITLE
support custom path to riffraff file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-riffraff-artefact",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Deploy RiffRaff Artefacts",
   "main": "dist/riffraff-artefact.js",
   "bin": {

--- a/src/riffraff-artefact.js
+++ b/src/riffraff-artefact.js
@@ -129,7 +129,7 @@ function createDirectories() {
 function copyResources() {
     const possibleActions = [
         [cloudformation, SETTINGS.cloudformation],
-        [deployJson, true]
+        [riffraffFile, true]
     ];
 
     return Q.all(possibleActions
@@ -147,9 +147,9 @@ function cloudformation() {
     ]);
 }
 
-function deployJson() {
+function riffraffFile() {
     return util.copyFile(
-        SETTINGS.rootDir + "/deploy.json",
+        SETTINGS.rootDir + "/" + SETTINGS.riffraffFile,
         SETTINGS.leadDir
     );
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -19,6 +19,7 @@ log("Reading configuration from " + ROOT + "/package.json");
 const packageJson = require(ROOT + "/package.json");
 const cf = packageJson.cloudformation;
 const projectName = packageJson.projectName;
+const riffraffFile = packageJson.riffraffFile || "/deploy.json";
 
 let SETTINGS = {
     rootDir: ROOT,
@@ -40,7 +41,8 @@ let SETTINGS = {
     packageDir: ROOT + "/target/riffraff/packages/" + packageJson.name,
     buildDir: packageJson.buildDir || undefined,
     bufferSize: parseInt(process.env.NODE_STDOUT_BUFFER || (1024 * 5000)),
-    env: ENVIRONMENT
+    env: ENVIRONMENT,
+    riffraffFile: riffraffFile
 };
 
 


### PR DESCRIPTION
provides support for the new riffraff.yaml file by reading `riffraffFile` value from `package.json`, defaulting to `/deploy.json`.