### PR TITLE
2.0.0 -> 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-riffraff-artefact",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Deploy RiffRaff Artefacts",
   "main": "dist/riffraff-artefact.js",
   "bin": {


### PR DESCRIPTION
bump version because yarn publish published an empty directory 