### PR TITLE
Allow for custom settings file

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -6,6 +6,7 @@ const ENVIRONMENT = determineEnvironment();
 
 const log = (process.env.VERBOSE === "true") ? console.log.bind(console) : function () {};
 
+const pkg = !process.env.CONFIG ? "package.json" : process.env.CONFIG;
 
 log("Determined running in: " + ENVIRONMENT);
 log("Root project path set as " + ROOT);

--- a/src/settings.js
+++ b/src/settings.js
@@ -15,9 +15,9 @@ log("Root project path set as " + ROOT);
  * To be valid packageJson,json must at the very least have
  * a name and a cloudformation field.
  */
-log("Reading configuration from " + ROOT + "/package.json");
+log("Reading configuration from " + ROOT + "/" + pkg);
 
-const packageJson = require(ROOT + "/package.json");
+const packageJson = require(ROOT + "/" + pkg);
 const cf = packageJson.cloudformation;
 const cloudformationAppTag = packageJson.cloudformationAppTag;
 const projectName = packageJson.projectName;


### PR DESCRIPTION
Pass a config file (that's not `package.json` as `process.env.CONFIG` 